### PR TITLE
Feature/#77  add graph control component

### DIFF
--- a/Assets/Scenes/Co2SensorScene.unity
+++ b/Assets/Scenes/Co2SensorScene.unity
@@ -1763,7 +1763,7 @@ RectTransform:
   m_Children:
   - {fileID: 306824071}
   m_Father: {fileID: 1814607059}
-  m_RootOrder: 17
+  m_RootOrder: 18
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -7415,6 +7415,7 @@ GameObject:
   - component: {fileID: 1814607059}
   - component: {fileID: 1814607061}
   - component: {fileID: 1814607060}
+  - component: {fileID: 1814607062}
   m_Layer: 5
   m_Name: LineChart
   m_TagString: Untagged
@@ -7450,8 +7451,8 @@ RectTransform:
   - {fileID: 1035588295}
   - {fileID: 464956244}
   - {fileID: 1729674800}
-  - {fileID: 285055970}
   - {fileID: 2072946192}
+  - {fileID: 285055970}
   m_Father: {fileID: 271208938}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -8773,6 +8774,22 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1814607058}
   m_CullTransparentMesh: 1
+--- !u!114 &1814607062
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1814607058}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c7540eef65badc846855a8213ebf8403, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  title: "CO2\u6FC3\u5EA6"
+  maxValue: 3000
+  minValue: 300
+  setXValue: 1
 --- !u!1 &1815547181
 GameObject:
   m_ObjectHideFlags: 0
@@ -9878,7 +9895,7 @@ RectTransform:
   - {fileID: 1123320836}
   - {fileID: 3640796}
   m_Father: {fileID: 1814607059}
-  m_RootOrder: 18
+  m_RootOrder: 17
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}

--- a/Assets/Scenes/Co2SensorScene.unity
+++ b/Assets/Scenes/Co2SensorScene.unity
@@ -5388,6 +5388,18 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+      - m_Target: {fileID: 1814607062}
+        m_TargetAssemblyTypeName: GraphRender, Assembly-CSharp
+        m_MethodName: UpdateSensorValue
+        m_Mode: 5
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: CO2
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &1125925885
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/CO2Scene/GraphRender.cs
+++ b/Assets/Scripts/CO2Scene/GraphRender.cs
@@ -76,6 +76,18 @@ public class GraphRender : MonoBehaviour
         }
     }
 
+    // センサーの取得情報に従ってグラフを更新する
+    public void UpdateSensorValue(string sensorName)
+    {
+        SensorDataManager sdm = SensorDataManager.Instance;
+        SensorData sensorData;
+        if( sdm == null || (sensorData = sdm.GetSensorData(sensorName)) == null )
+        {
+            return;
+        }
+        UpdateDataXY(sensorData.times, sensorData.datas);
+    }
+
     // Y軸のデータを更新する（X軸方向は横に一定間隔に並ぶ）
     void UpdateYData(List<int> datas)
     {

--- a/Assets/Scripts/CO2Scene/GraphRender.cs
+++ b/Assets/Scripts/CO2Scene/GraphRender.cs
@@ -27,6 +27,7 @@ public class GraphRender : MonoBehaviour
         {
             serie = chart.AddSerie<Serie>();
         }
+        serie.ClearData();
 
         // ƒ^ƒCƒgƒ‹‚ğİ’è
         Title title = chart.GetChartComponent<Title>();
@@ -43,6 +44,7 @@ public class GraphRender : MonoBehaviour
         if( setXValue )
         {
             xAxis.type = Axis.AxisType.Value;
+            xAxis.minMaxType = Axis.AxisMinMaxType.MinMax;
         }
         else
         {

--- a/Assets/Scripts/CO2Scene/GraphRender.cs
+++ b/Assets/Scripts/CO2Scene/GraphRender.cs
@@ -1,0 +1,102 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using XCharts.Runtime;
+
+[RequireComponent(typeof(LineChart))]
+public class GraphRender : MonoBehaviour
+{
+    [SerializeField] private string title = "CO2濃度";
+    [SerializeField] private int maxValue = 3000;
+    [SerializeField] private int minValue = 300;
+    [SerializeField] private bool setXValue = true;
+
+    private LineChart chart;
+    private Serie serie;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        // LineChartとSerieを取得
+        chart = GetComponent<LineChart>();
+        if(chart.series.Count > 0)
+        {
+            serie = chart.series[0];
+        }
+        else
+        {
+            serie = chart.AddSerie<Serie>();
+        }
+
+        // タイトルを設定
+        Title title = chart.GetChartComponent<Title>();
+        title.text = this.title;
+
+        // Y軸の最大値と最小値を設定
+        YAxis axis = chart.GetChartComponent<YAxis>();
+        axis.minMaxType = Axis.AxisMinMaxType.Custom;
+        axis.min = minValue;
+        axis.max = maxValue;
+
+        // X軸のタイプを値に変更
+        XAxis xAxis = chart.GetChartComponent<XAxis>();
+        if( setXValue )
+        {
+            xAxis.type = Axis.AxisType.Value;
+        }
+        else
+        {
+            xAxis.type = Axis.AxisType.Category;
+        }
+    }
+
+    // 5秒毎にランダムな値にグラフを更新してデバッグする
+    [ContextMenu("Debug/GraphUpdateTest")]
+    private void GraphUpdateTest()
+    {
+        StartCoroutine(UpdateRandomValue());
+    }
+
+    private IEnumerator UpdateRandomValue()
+    {
+        List<long> datax = new List<long>() { 0, 1, 2, 3, 5};
+        List<int> datas = new List<int>();
+        for(int i = 0; i < 5; i++)
+        {
+            datas.Add(Random.Range(600, 700));
+        }
+        WaitForSeconds wait = new WaitForSeconds(5);
+        while (true)
+        {
+            datas.Add(Random.Range(600, 700));
+            datas.RemoveAt(0);
+            UpdateDataXY(datax, datas);
+            //UpdateData(datas);
+            yield return wait;
+        }
+    }
+
+    // Y軸のデータを更新する（X軸方向は横に一定間隔に並ぶ）
+    void UpdateYData(List<int> datas)
+    {
+        serie.ClearData();
+
+        for(int i = 0; i < datas.Count; i++)
+        {
+            SerieData addData = new SerieData();
+            addData.data = new List<double> { i, datas[i] };
+            serie.AddSerieData(addData);
+        }
+    }
+
+    // X軸Y軸セットのデータを更新する
+    void UpdateDataXY(List<long> dataX, List<int> dataY)
+    {
+        serie.ClearData();
+
+        for (int i = 0; i < dataX.Count; i++)
+        {
+            serie.AddXYData(dataX[i], dataY[i]);
+        }
+    }
+}

--- a/Assets/Scripts/CO2Scene/GraphRender.cs.meta
+++ b/Assets/Scripts/CO2Scene/GraphRender.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c7540eef65badc846855a8213ebf8403
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
#77
グラフを更新するComponentを追加した。
- センサーの値が取得できない場合、グラフオブジェクトのインスペクタに移り、GraphRenderのコンテキストメニューのDebug/GraphUpdateTestから5秒おきに600~700のランダムな値が更新される。

- センサーの値を取得すると、グラフが横軸時間、縦軸濃度で更新される。データが一つだけ古いなどの理由で時間が上手く設定されていないとグラフが上手く描画されないので注意。
